### PR TITLE
nix: configuration and systemd service fixes

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -37,14 +37,18 @@ in {
   };
 
   config = mkIf cfg.enable {
+    # Create the batmon configuration file in /etc/batmon.json
+    environment.etc."batmon.json".source = format.generate "batmon.json" cfg.settings;
+
     environment.systemPackages = [cfg.package];
+
     systemd.user.services.batmon = {
       description = "Simple, reactive power management service";
       documentation = ["https://github.com/NotAShelf/batmon"];
       wantedBy = ["multi-user.target"];
       environment.PATH = mkForce "/run/wrappers/bin:${lib.makeBinPath [cfg.package]}";
       script = ''
-        ${lib.getExe cfg.package} --config ${builtins.toJSON cfg.settings}
+        ${lib.getExe cfg.package} --config /etc/batmon.json
       '';
 
       serviceConfig = {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -41,8 +41,6 @@ in {
     systemd.user.services.batmon = {
       description = "Simple, reactive power management service";
       documentation = ["https://github.com/NotAShelf/batmon"];
-      wants = ["power-profiles-daemon.service"];
-      requires = ["power-profiles-daemon.service"];
       wantedBy = ["multi-user.target"];
       environment.PATH = mkForce "/run/wrappers/bin:${lib.makeBinPath [cfg.package]}";
       script = ''

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -52,7 +52,6 @@ in {
       serviceConfig = {
         Type = "simple";
         Restart = "on-failure";
-        DynamicUser = true;
       };
     };
   };


### PR DESCRIPTION
- user services do not use the DynamicUser option, including it causes the service to fail starting.
- you can't reference system services in systemd user services, so remove references to the systems `power-profiles-daemon.service` (probably a better way to do this)
- previously in the nix module, the config in json format would be passed to the --config option as text. --config is looking for a path though, so write the configured config to `/etc/batmon.json` and read from that instead.

with these changes, the nix module almost works, however it fails to run the default powerprofilesctl command, probably because its not in systemd PATH. How can we expose the path to that binary to the service?