### PR TITLE
nix: set wantedBy to default.target instead of multi-user.target

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -50,7 +50,7 @@ in {
     systemd.user.services.batmon = {
       description = "Simple, reactive power management service";
       documentation = ["https://github.com/NotAShelf/batmon"];
-      wantedBy = ["multi-user.target"];
+      wantedBy = ["default.target"];
       environment.PATH = mkForce "/run/wrappers/bin:${lib.makeBinPath [
         # Batmon expects powerprofilesctl in PATH
         config.services.power-profiles-daemon.package


### PR DESCRIPTION
for the same reason that we removed references to `power-profiles-daemon.service`, we also need to change the reference to `multi-user.target` to a user level systemd target. The best candidate being `default.target`

With this change the systemd service now correctly starts automatically. Previously it would not. I didn't realise because I had manually started the service so it worked, but rebooting showed that the service wasn't starting. I can confirm it's fixed on my end.